### PR TITLE
Update urdfdom.rb

### DIFF
--- a/urdfdom.rb
+++ b/urdfdom.rb
@@ -8,8 +8,8 @@ class Urdfdom < Formula
   depends_on "cmake" => :build
   depends_on "boost" => :build
   depends_on "tinyxml" => :build
-  depends_on "ros/deps/console_bridge"
-  depends_on "ros/deps/urdfdom_headers"
+  depends_on "console_bridge"
+  depends_on "urdfdom_headers"
 
   def install
     system "cmake", ".", *std_cmake_args


### PR DESCRIPTION
Remove tap in depends_on key.

The reference to the tap is not needed and if anything only a hinderance (e.g. if some installs their custom version of those packages from their own tap). Also, rosdep can't properly resolve the dependency that way (note the warning at the end):

```
$ rosdep install --from-paths src --ignore-src --rosdistro indigo
executing command [brew install urdfdom_headers]
==> Downloading https://github.com/ros/urdfdom_headers/archive/0.2.3.tar.gz
######################################################################## 100,0%
==> cmake . -DCMAKE_INSTALL_PREFIX=/usr/local/Cellar/urdfdom_headers/0.2.3 -DCMAKE_BUILD_TYPE=None -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_VERBOSE_MAKEFILE=ON -Wno-dev
==> make install
🍺  /usr/local/Cellar/urdfdom_headers/0.2.3: 16 files, 84K, built in 4 seconds
executing command [brew install urdfdom]
==> Installing urdfdom dependency: ros/deps/console_bridge
==> Downloading https://github.com/ros/console_bridge/archive/0.2.5.tar.gz
######################################################################## 100,0%
==> cmake . -DCMAKE_INSTALL_PREFIX=/usr/local/Cellar/console_bridge/0.2.5 -DCMAKE_BUILD_TYPE=None -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_VERBOSE_MAKEFILE=ON -Wno-dev
==> make install
🍺  /usr/local/Cellar/console_bridge/0.2.5: 6 files, 72K, built in 4 seconds
==> Installing urdfdom
==> Downloading https://github.com/ros/urdfdom/archive/0.2.10.tar.gz
######################################################################## 100,0%
==> cmake . -DCMAKE_INSTALL_PREFIX=/usr/local/Cellar/urdfdom/0.2.10 -DCMAKE_BUILD_TYPE=None -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_VERBOSE_MAKEFILE=ON -Wno-dev
==> make install
🍺  /usr/local/Cellar/urdfdom/0.2.10: 14 files, 712K, built in 8 seconds
executing command [brew install console_bridge]
Warning: console_bridge-0.2.5 already installed
#All required rosdeps installed successfully
```
