### PR TITLE
Remove the flaky OSS mirror. 

### DIFF
--- a/uuid.rb
+++ b/uuid.rb
@@ -2,8 +2,7 @@ require 'formula'
 
 class Uuid < Formula
   homepage 'http://www.ossp.org/pkg/lib/uuid/'
-  url 'ftp://ftp.ossp.org/pkg/lib/uuid/uuid-1.6.2.tar.gz'
-  mirror 'http://gnome-build-stage-1.googlecode.com/files/uuid-1.6.2.tar.gz'
+  url 'http://gnome-build-stage-1.googlecode.com/files/uuid-1.6.2.tar.gz'
   sha1 '3e22126f0842073f4ea6a50b1f59dcb9d094719f'
 
   option :universal


### PR DESCRIPTION
There are two existing issues on Github on this (https://github.com/Homebrew/homebrew/issues/14265), this is the third instance, so we really should not be using their server at all. It fails part into the FTP transaction, so despite the fact that there would be a fallback mirror, it just sits there and waits.

This and the PyQt fix bring the ROS Indigo installation tutorial back into an operational state.
