### PR TITLE
Fixes previously commited hashes to the correct value

### DIFF
--- a/console_bridge.rb
+++ b/console_bridge.rb
@@ -3,7 +3,7 @@ require "formula"
 class ConsoleBridge < Formula
   homepage "http://wiki.ros.org/console_bridge"
   url "https://github.com/ros/console_bridge/archive/0.2.5.tar.gz"
-  sha256 "6e4f3e8a56903f157829d8928b9ed8c8c9e1cc16f281a90ecd2abfdc904a3b92"
+  sha256 "a8843e1d8447c099ef271a942af1c57294c4c51f43bbde2c6d03f7b805989fa7"
 
   depends_on "cmake" => :build
   depends_on "boost" => :build

--- a/mongodb-dev.rb
+++ b/mongodb-dev.rb
@@ -3,7 +3,7 @@ require 'formula'
 class MongodbDev < Formula
   homepage 'http://www.mongodb.org/'
   url 'https://github.com/mongodb/mongo/archive/r2.5.4.tar.gz'
-  sha256 '2c073a48d65efbf40106604d700c701a4bcbe1f600a7ec7ddade9b0c377d1116'
+  sha256 "95b078ccec581b58e7f36bcd66e8d3d874101f26e9d53787f230683d3cc8cebb"
   version '2.5.4'
 
   depends_on 'scons'

--- a/pyassimp.rb
+++ b/pyassimp.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Pyassimp < Formula
   homepage 'http://assimp.sourceforge.net/'
   url 'http://sourceforge.net/projects/assimp/files/assimp-2.0/assimp--2.0.863-sdk.zip'
-  sha256 '0792e844a808b5ea53b0590031bdd6cc03b9895e90dfd2cd6422423188d8a94c'
+  sha256 '4d7a048f9284e14904fcfc973fc4234f15ee4932e88f901ff82b6aaabaec9082'
 
   depends_on :python => :recommended
   depends_on 'assimp'

--- a/urdfdom.rb
+++ b/urdfdom.rb
@@ -3,7 +3,7 @@ require "formula"
 class Urdfdom < Formula
   homepage "http://wiki.ros.org/urdf"
   url "https://github.com/ros/urdfdom/archive/0.2.10.tar.gz"
-  sha256 "2171c61bc6f46575fb0847112b4b7c766a6d664da83bfa327692ba99fc474041"
+  sha256 "e200f5adefa6bf8304e56ab8a3e1c04d3b6cced5df472f4aeb430ff81f1ffa0d"
 
   depends_on "cmake" => :build
   depends_on "boost" => :build

--- a/urdfdom_headers.rb
+++ b/urdfdom_headers.rb
@@ -3,7 +3,7 @@ require "formula"
 class UrdfdomHeaders < Formula
   homepage "http://wiki.ros.org/urdfdom_headers"
   url "https://github.com/ros/urdfdom_headers/archive/0.2.3.tar.gz"
-  sha256 "b0a707c77d6defc567b3fd2bdc6b74fc7e190504e50653107a0725ea22ae086f"
+  sha256 "6b1f27b002c6d897b43ed57988133f40aac093a2a6e84d9bf08ed36a13b401ae"
 
   depends_on "cmake" => :build
 

--- a/yaml-cpp-0.3.rb
+++ b/yaml-cpp-0.3.rb
@@ -3,7 +3,7 @@ require 'formula'
 class YamlCpp03 < Formula
   homepage 'http://code.google.com/p/yaml-cpp/'
   url 'http://yaml-cpp.googlecode.com/files/yaml-cpp-0.3.0.tar.gz'
-  sha256 '2cd038b5a1583b6745e949e196fba525f6d0d5fd340566585fde24fc7e117b82'
+  sha256 "2cd038b5a1583b6745e949e196fba525f6d0d5fd340566585fde24fc7e117b82"
 
   depends_on 'cmake' => :build
 


### PR DESCRIPTION
I erroneously commited wrong hashes due to my script using the wrong `curl` options, which made it not follow redirects.

This fixes the issue highlighted at https://github.com/ros/homebrew-groovy/issues/7 as well (will open a new PR for the other repo).