### PR TITLE
Fix deprecation of python.xy formula in pyassimp build.

### DIFF
--- a/pyassimp.rb
+++ b/pyassimp.rb
@@ -13,7 +13,7 @@ class Pyassimp < Formula
   end
 
   def install
-    temp_site_packages = lib/python.xy/'site-packages'
+    temp_site_packages = lib+"python2.7/site-packages"
 
     args = [
       "--verbose",
@@ -23,11 +23,11 @@ class Pyassimp < Formula
     ]
 
     # build the pyassimp libraries
-    system python, "-s", "setup.py", *args
+    system "python", "-s", "setup.py", *args
   end
 
   test do
-    system python, "-c", "'import pyassimp'"
+    system "python", "-c", "'import pyassimp'"
   end
 end
 


### PR DESCRIPTION
Fix the deprecation of python.xy.
Error: undefined method `xy' for #<PythonRequirement: "python" []>

This is copied from:
  https://github.com/ros/homebrew-hydro/pull/25