### PR TITLE
Update to urdfdom_headers 1.0.0

### DIFF
--- a/console_bridge.rb
+++ b/console_bridge.rb
@@ -7,6 +7,7 @@ class ConsoleBridge < Formula
 
   depends_on "cmake" => :build
   depends_on "boost" => :build
+  depends_on "pkg-config" => :build # for test
 
   def install
     system "cmake", ".", *std_cmake_args

--- a/urdfdom_headers.rb
+++ b/urdfdom_headers.rb
@@ -1,9 +1,8 @@
-require "formula"
-
 class UrdfdomHeaders < Formula
+  desc "Headers for URDF parsers "
   homepage "http://wiki.ros.org/urdfdom_headers"
-  url "https://github.com/ros/urdfdom_headers/archive/0.2.3.tar.gz"
-  sha256 "6b1f27b002c6d897b43ed57988133f40aac093a2a6e84d9bf08ed36a13b401ae"
+  url "https://github.com/ros/urdfdom_headers/archive/1.0.0.tar.gz"
+  sha256 "f341e9956d53dc7e713c577eb9a8a7ee4139c8b6f529ce0a501270a851673001"
 
   depends_on "cmake" => :build
 
@@ -13,6 +12,6 @@ class UrdfdomHeaders < Formula
   end
 
   test do
-    system "pkg-config --cflags-only-I urdfdom_headers"
+    system "pkg-config", "--cflags-only-I", "urdfdom_headers"
   end
 end

--- a/urdfdom_headers.rb
+++ b/urdfdom_headers.rb
@@ -3,6 +3,7 @@ class UrdfdomHeaders < Formula
   homepage "http://wiki.ros.org/urdfdom_headers"
   url "https://github.com/ros/urdfdom_headers/archive/1.0.0.tar.gz"
   sha256 "f341e9956d53dc7e713c577eb9a8a7ee4139c8b6f529ce0a501270a851673001"
+  head "https://github.com/ros/urdfdom_headers", :branch => "master"
 
   depends_on "cmake" => :build
 

--- a/urdfdom_headers.rb
+++ b/urdfdom_headers.rb
@@ -13,6 +13,6 @@ class UrdfdomHeaders < Formula
   end
 
   test do
-    system "pkg-config", "--cflags-only-I", "urdfdom_headers"
+    system "brew", "list", "urdfdom_headers"
   end
 end


### PR DESCRIPTION
This PR:
* updates to urdfdom_headers 1.0.0
* addresses warnings per `brew audit --strict`