### PR TITLE
Setup Travis-CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+language: ruby
+
+matrix:
+  include:
+    - env: OSX=10.12
+      os: osx
+      osx_image: xcode8.1
+      rvm: system
+    - env: OSX=10.11
+      os: osx
+      osx_image: xcode7.3
+      rvm: system
+
+before_install:
+  - export TRAVIS_COMMIT="$(git rev-parse --verify -q HEAD)"
+  - if [ -f ".git/shallow" ]; then
+      travis_retry git fetch --unshallow;
+    fi
+  - HOMEBREW_REPOSITORY="$(brew --repo)"
+  - sudo chown -R "$USER" "$HOMEBREW_REPOSITORY"
+  - git -C "$HOMEBREW_REPOSITORY" reset --hard origin/master
+  - brew update || brew update
+  - HOMEBREW_TAP_DIR="$(brew --repo "$TRAVIS_REPO_SLUG")"
+  - mkdir -p "$HOMEBREW_TAP_DIR"
+  - rm -rf "$HOMEBREW_TAP_DIR"
+  - ln -s "$PWD" "$HOMEBREW_TAP_DIR"
+  - export HOMEBREW_DEVELOPER="1"
+  - ulimit -n 1024
+
+script:
+  - brew test-bot
+
+notifications:
+  email:
+    on_success: never
+    on_failure: always

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# homebrew-deps [![Build Status](https://travis-ci.org/ros/homebrew-deps.svg?branch=master)](https://travis-ci.org/ros/homebrew-deps)
+Homebrew Formula for common system ROS dependencies


### PR DESCRIPTION
It would be nice to test the formulae when PRs are submitted. The `.travis.yml` is written by referred [the recommended approach](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/tap-new.rb#L46-L76). The Travis-CI service for this repo should be enabled to make this work.