### PR TITLE
Update gtest.rb

### DIFF
--- a/gtest.rb
+++ b/gtest.rb
@@ -14,7 +14,7 @@ class Gtest < Formula
     # This is necessary to get gtest to function wtih libc++
     # Otherwise, every catkin package has to export that flag.
     # The patch only changes the default behavior.
-    DATA
+    :DATA
   end
 
   def install


### PR DESCRIPTION
Fix patch as described by @MikeChou in https://github.com/ros/homebrew-deps/issues/34. The error was:

> ######################################################################## 100.0%
> Error: uninitialized constant #<Class:0x007fb335048a40>::DATA
> Did you mean?  Data
>                Date
> Please report this bug:
>   https://docs.brew.sh/Troubleshooting
> /usr/local/Homebrew/Library/Taps/ros/homebrew-deps/gtest.rb:17:in `patches'
> /usr/local/Homebrew/Library/Homebrew/formula.rb:1932:in `prepare_patches'
> /usr/local/Homebrew/Library/Homebrew/formula.rb:1095:in `block in brew'
> /usr/local/Homebrew/Library/Homebrew/formula.rb:1923:in `block (2 levels) in stage'
> /usr/local/Homebrew/Library/Homebrew/utils.rb:556:in `with_env'
> /usr/local/Homebrew/Library/Homebrew/formula.rb:1922:in `block in stage'
> /usr/local/Homebrew/Library/Homebrew/resource.rb:119:in `block in unpack'
> /usr/local/Homebrew/Library/Homebrew/extend/fileutils.rb:13:in `block in mktemp'
> /usr/local/Homebrew/Library/Homebrew/extend/fileutils.rb:73:in `block in run'
> /usr/local/Homebrew/Library/Homebrew/extend/fileutils.rb:73:in `chdir'
> /usr/local/Homebrew/Library/Homebrew/extend/fileutils.rb:73:in `run'
> /usr/local/Homebrew/Library/Homebrew/extend/fileutils.rb:12:in `mktemp'
> /usr/local/Homebrew/Library/Homebrew/resource.rb:114:in `unpack'
> /usr/local/Homebrew/Library/Homebrew/resource.rb:92:in `stage'
> /usr/local/Homebrew/Library/Homebrew/formula.rb:1900:in `stage'
> /usr/local/Homebrew/Library/Homebrew/formula.rb:1093:in `brew'
> /usr/local/Homebrew/Library/Homebrew/build.rb:111:in `block in install'
> /usr/local/Homebrew/Library/Homebrew/utils.rb:556:in `with_env'
> /usr/local/Homebrew/Library/Homebrew/build.rb:108:in `install'
> /usr/local/Homebrew/Library/Homebrew/build.rb:189:in `<main>'
> ERROR: the following rosdeps failed to install
>   homebrew: command [brew install gtest] failed