### PR TITLE
Updated gfortran.rb

### DIFF
--- a/gfortran.rb
+++ b/gfortran.rb
@@ -12,7 +12,7 @@ class Gfortran < Formula
 
   option 'enable-profiled-build', 'Make use of profile guided optimization when bootstrapping GCC'
   option 'check', 'Run the make check fortran. This is for maintainers.'
-  option 'enable-multilib', 'Build with multilib support' if MacOS.prefer_64_bit?
+  option 'enable-multilib', 'Build with multilib support' if Hardware::CPU.is_64_bit?
 
   depends_on 'gmp'
   depends_on 'libmpc'
@@ -60,7 +60,7 @@ class Gfortran < Formula
     ]
 
     # https://github.com/Homebrew/homebrew/issues/19584#issuecomment-19661219
-    if build.include? 'enable-multilib' and MacOS.prefer_64_bit?
+    if build.include? 'enable-multilib' and Hardware::CPU.is_64_bit?
       args << '--enable-multilib'
     else
       args << '--disable-multilib'


### PR DESCRIPTION
Substituted MacOS.prefer_64_bit? for Hardware::CPU.is_64_bit? to allow new Homebrew installations tap on ros/deps